### PR TITLE
Restore english source copy from pre-0589d43 reference

### DIFF
--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -78,10 +78,10 @@
     "message": "Shira is open-source and licensed under MIT 2.0."
   },
   "about.how.design": {
-    "message": "At Horizontal, we design and develop centering the needs of the community."
+    "message": "At Horizontal, we design and develop centering the needs of users facing high risks of digital attacks."
   },
   "about.how.community": {
-    "message": "Shira is multilingual, co-created with users and centering security and privacy."
+    "message": "Shira is multilingual and co-created with at-risk users."
   },
   "about.how.green": {
     "message": "This website runs on green energy."
@@ -102,13 +102,13 @@
     "message": "Let’s talk!"
   },
   "contact.intro.part1": {
-    "message": "Do you have questions about Shira (that are not answered in our"
+    "message": "Do you have questions about Shira that are not answered in our"
   },
   "contact.intro.helpCenter": {
     "message": "help center"
   },
   "contact.intro.part2": {
-    "message": ")? Would you like to explore a possible partnership? Are you a part of a grassroots organization and cannot afford the full cost of Shira?"
+    "message": "? Would you like to explore a possible partnership? Are you a non-profit or a grassroots organization and cannot afford the full cost of Shira?"
   },
   "contact.getInTouch": {
     "message": "Get in touch:"
@@ -117,7 +117,7 @@
     "message": "Write to us at"
   },
   "contact.links.github": {
-    "message": "Post a feature idea or vote on the community needs"
+    "message": "Post a feature idea or vote on existing requests"
   },
   "contact.links.demo": {
     "message": "Schedule a demo call directly here"
@@ -171,43 +171,43 @@
     "message": "User-friendly interface 🎨"
   },
   "features.list.ui.description": {
-    "message": "Intuitive dashboard for easy navigation and management of quizzes and user data."
+    "message": "Intuitive dashboard for easy navigation and management of quizzes and users."
   },
   "features.list.roles.title": {
     "message": "Role-based access control 🔒"
   },
   "features.list.roles.description": {
-    "message": "Different access levels for admins, managers, and employees."
+    "message": "Different access levels for admins and learners."
   },
   "features.list.realLife.title": {
     "message": "Real-Life Attack Simulation ⚡"
   },
   "features.list.realLife.description": {
-    "message": "Ability to input details from actual phishing attacks the company has experienced."
+    "message": "Include in your quizzes details from actual phishing attacks the company has experienced to best prepare your team."
   },
   "features.list.email.title": {
     "message": "Email phishing simulations 📧"
   },
   "features.list.email.description": {
-    "message": "Create quizzes that mimic phishing emails on Gmail and Outlook, including headers, body, images and attachments."
+    "message": "Create quizzes that mimic phishing emails on Gmail and Outlook, including sender information, subject line, email body, links, images and file attachments."
   },
   "features.list.sms.title": {
     "message": "SMS phishing simulations 💬"
   },
   "features.list.sms.description": {
-    "message": "Design quizzes that simulate SMS phishing attempts with realistic text messages."
+    "message": "Create quizzes that simulate SMS phishing attempts with realistic text messages."
   },
   "features.list.messaging.title": {
     "message": "Messaging app phishing simulations 💬"
   },
   "features.list.messaging.description": {
-    "message": "Include quizzes that replicate phishing through WhatsApp, Messenger, etc."
+    "message": "Create quizzes that replicate phishing through popular messaging apps like WhatsApp or Facebook Messenger."
   },
   "features.list.mobile.title": {
     "message": "Mobile support 📱"
   },
   "features.list.mobile.description": {
-    "message": "Users can take Shira quizzes on mobile devices to simulate real-life scenarios."
+    "message": "We often face phishing attacks from our mobile devices. In Shira, users can take quizzes from their mobile devices to prepare for attacks they will face in real life."
   },
   "features.list.compliance.title": {
     "message": "Compliance ✅"
@@ -219,19 +219,19 @@
     "message": "Analytics 📈"
   },
   "features.list.analytics.description": {
-    "message": "Track user progress and identify areas for improvement."
+    "message": "Track user progress and identify areas for improvement, whether it's the type of apps your users are most vulnerable on or the specific users who need extra support."
   },
   "features.list.explanations.title": {
     "message": "Explanations 📝"
   },
   "features.list.explanations.description": {
-    "message": "Embed your own explanations on why an email or message looks like phishing."
+    "message": "Embed your own explanations to point users to elements that suggest that an email or message looks like phishing."
   },
   "features.list.gamification.title": {
     "message": "Gamification 🕹️"
   },
   "features.list.gamification.description": {
-    "message": "An entertaining learning experience promotes better knowledge retention."
+    "message": "An engaging learning experience promotes better knowledge retention."
   },
   "features.list.multilingual.title": {
     "message": "Multilingual 🌐"
@@ -243,7 +243,7 @@
     "message": "Question library 📚"
   },
   "features.list.library.description": {
-    "message": "Pull from Shira's question library to start your trainings from templates created by digital security trainers."
+    "message": "Create your quiz questions from scratch or head to the Shira Library to pull question templates created by digital security trainers."
   },
   "features.needMore.title": {
     "message": "Missing a feature?"
@@ -258,7 +258,7 @@
     "message": "Shira"
   },
   "homepage.meta.description": {
-    "message": "Shira builds your team's ability to identify and defeat phishing attacks."
+    "message": "Use Shira to build your team's ability to identify and defeat phishing attacks."
   },
   "homepage.meta.longDescription": {
     "message": "Shira helps individuals and organizations learn to spot and defeat phishing attacks through interactive, privacy-friendly quizzes, customizable for real-world apps like Gmail, SMS, and WhatsApp, context and language."
@@ -273,7 +273,7 @@
     "message": "For learners"
   },
   "homepage.learners.description": {
-    "message": "Get started right away with one of our free, ready-made quizzes. Customize the quiz to learn to identify phishing in the apps you use in real life — Gmail, SMS, WhatsApp, etc — with examples tailored to your language and field of work."
+    "message": "Get started right away with one of our free, ready-made quizzes. Customize the quiz to learn to identify phishing in the apps you use every day — Gmail, SMS, WhatsApp, etc — with examples tailored to your language and field of work."
   },
   "homepage.learners.cta": {
     "message": "Take a quiz"
@@ -282,13 +282,13 @@
     "message": "For educators and security professionals"
   },
   "homepage.educators.description": {
-    "message": "Each organization has its own needs and faces its own threats. Build phishing quizzes tailored to your organization’s needs and monitor your team’s success rates — all without technical skills."
+    "message": "Each organization has its own needs and faces its own threats. Build phishing quizzes tailored to your organization’s needs and monitor your team’s success rates — without any coding."
   },
   "homepage.educators.cta": {
     "message": "Create your own quiz"
   },
   "homepage.context.description": {
-    "message": "For years, phishing has been one of the most common types of attacks facing individuals and organizations. While it has been traditionally limited to emails, phishing now also happens via SMS, messaging apps, and social media. Building users’ skills to identify and defeat phishing attacks is more needed than ever before."
+    "message": "For years, phishing has been one of the most common attacks facing individuals and organizations. While it was initially limited to emails, phishing now also happens via SMS, messaging apps, and social media. Building users’ skills to identify and defeat phishing attacks is more needed than ever before."
   },
   "homepage.context.imageAlt": {
     "message": "decorative image of a magnifier glass"
@@ -297,7 +297,7 @@
     "message": "Why Shira?"
   },
   "homepage.why.intro": {
-    "message": "Whether you’re just taking our ready-made, free quizzes, or you’re taking the time to build your own custom quizzes, Shira is:"
+    "message": "Whether you’re just taking our ready-made, free quizzes, or you’re building your own custom quizzes to train your team, Shira is:"
   },
   "homepage.why.easy.title": {
     "message": "Easy to use"
@@ -315,13 +315,13 @@
     "message": "Privacy-friendly"
   },
   "homepage.why.privacy.description": {
-    "message": "We do not collect or share any user data."
+    "message": "We do not collect or share any sensitive or personally-identifiable user data."
   },
   "phishingQuizzes.meta.title": {
-    "message": "Learn about Phishing quizzes"
+    "message": "Learn about Phishing Quizzes"
   },
   "phishingQuizzes.meta.description": {
-    "message": "Learn why phishing quizzes are more effective than simulations. Shira offers safe, interactive training to build real phishing detection skills without stress or punishment."
+    "message": "Learn about Phishing quizzes"
   },
   "phishingQuizzes.education.title": {
     "message": "Why education beats simulation"
@@ -333,10 +333,10 @@
     "message": "However, this approach has several drawbacks and is not as effective as providing comprehensive anti-phishing education."
   },
   "phishingQuizzes.wsj.alt": {
-    "message": "news article from the wall street journal Phishing Tests, the Bane of Work Life, Are Getting Meaner - Researchers say the ruses, aimed at teaching gullible employees about the dangers lurking online, don’t even work"
+    "message": "news article from the Wall Street Journal: 'Phishing Tests, the Bane of Work Life, Are Getting Meaner'- Researchers say the ruses, aimed at teaching gullible employees about the dangers lurking online, don’t even work"
   },
   "phishingQuizzes.wsjMobile.alt": {
-    "message": "news article from the wall street journal Phishing Tests, the Bane of Work Life, Are Getting Meaner - Researchers say the ruses, aimed at teaching gullible employees about the dangers lurking online, don’t even work"
+    "message": "news article from the Wall Street Journal: 'Phishing Tests, the Bane of Work Life, Are Getting Meaner'- Researchers say the ruses, aimed at teaching gullible employees about the dangers lurking online, don’t even work"
   },
   "phishingQuizzes.problem.title": {
     "message": "The problem with phishing simulations"
@@ -354,31 +354,31 @@
     "message": "Narrow Focus on Email:"
   },
   "phishingQuizzes.problem.emailFocus.text": {
-    "message": "Many phishing simulations primarily target email threats, overlooking other channels like SMS, messaging apps, or social media. This limited focus can leave employees unprepared to recognize and respond to phishing attempts outside their email inbox."
+    "message": "Many phishing simulations primarily target email threats, overlooking other channels like SMS, messaging apps, or social media."
   },
   "phishingQuizzes.problem.falseSecurity.title": {
     "message": "False Sense of Security:"
   },
   "phishingQuizzes.problem.falseSecurity.text": {
-    "message": "If employees successfully identify simulated phishing attempts, they may develop a false sense of security, believing they are fully equipped to handle real threats, which can lead to complacency."
+    "message": "If employees successfully identify simulated phishing attempts, they may develop a false sense of security."
   },
   "phishingQuizzes.problem.clickRates.title": {
     "message": "Overemphasis on Click Rates:"
   },
   "phishingQuizzes.problem.clickRates.text": {
-    "message": "Focusing solely on whether employees clicked on a link can overlook other important aspects of phishing awareness, such as recognizing social engineering tactics or reporting suspicious emails."
+    "message": "Focusing solely on whether employees clicked on a link can overlook other important aspects of phishing awareness."
   },
   "phishingQuizzes.problem.desensitize.title": {
     "message": "Desensitize users:"
   },
   "phishingQuizzes.problem.desensitize.text": {
-    "message": "Repeatedly sending fake phishing emails can desensitize users to the threat, making them less likely to take real phishing attempts seriously."
+    "message": "Repeatedly sending fake phishing emails can desensitize users to the threat."
   },
   "phishingQuizzes.problem.punishment.title": {
     "message": "Focus on punishment rather than prevention:"
   },
   "phishingQuizzes.problem.punishment.text": {
-    "message": "Simulated phishing emails can create a culture of fear, where users are more focused on avoiding punishment than on learning how to prevent phishing attacks."
+    "message": "Simulated phishing emails can create a culture of fear, where users are more focused on avoiding punishment than on learning."
   },
   "phishingQuizzes.research.text": {
     "message": "Research finds that phishing simulation campaigns do not effectively train people in identifying phishing attacks."
@@ -393,13 +393,13 @@
     "message": "counterproductive"
   },
   "phishingQuizzes.research.final": {
-    "message": "effect of phishing simulations: users who are continuously exposed to phishing simulations are more likely to click on dangerous links."
+    "message": "effect of phishing simulations."
   },
   "phishingQuizzes.quizzes.title": {
     "message": "A more effective approach: phishing quizzes"
   },
   "phishingQuizzes.quizzes.description": {
-    "message": "Phishing quizzes provide a controlled learning environment that is more effective for skill-building than traditional phishing simulations. Unlike simulations, which can be stressful and punitive, quizzes offer a safe and interactive space for employees to practice their phishing detection skills. Designed to mimic real-world scenarios without actual risk, these quizzes encourage active learning and allow participants to receive immediate feedback. This helps employees learn from their mistakes, build confidence, and understand why certain emails are phishing attempts."
+    "message": "Phishing quizzes provide a controlled learning environment that is more effective for skill-building than traditional phishing simulations."
   },
   "phishingQuizzes.quizzes.benefitsIntro": {
     "message": "Benefits include:"
@@ -408,31 +408,31 @@
     "message": "Controlled Learning Environment:"
   },
   "phishingQuizzes.benefits.controlled.text": {
-    "message": "Phishing quizzes create a safe and low-stakes space for employees to practice their skills, reducing the stress and anxiety often associated with traditional phishing simulations."
+    "message": "Phishing quizzes create a safe and low-stakes space for employees to practice their skills."
   },
   "phishingQuizzes.benefits.interactive.title": {
     "message": "Interactive Engagement:"
   },
   "phishingQuizzes.benefits.interactive.text": {
-    "message": "These quizzes encourage active participation by allowing employees to engage with various phishing scenarios, while also providing immediate feedback on what elements indicate that an email or message may be a phishing attack."
+    "message": "These quizzes encourage active participation and provide immediate feedback."
   },
   "phishingQuizzes.benefits.coverage.title": {
     "message": "Coverage of Diverse Phishing Tactics:"
   },
   "phishingQuizzes.benefits.coverage.text": {
-    "message": "Phishing quizzes can incorporate questions about various types of phishing attacks, such as SMS (smishing), social media, and voice calls (vishing), broadening employees' awareness and preparedness for threats beyond just email."
+    "message": "Phishing quizzes can incorporate SMS, social media, and voice phishing scenarios."
   },
   "phishingQuizzes.benefits.confidence.title": {
     "message": "Confidence Building:"
   },
   "phishingQuizzes.benefits.confidence.text": {
-    "message": "By allowing employees to learn from their mistakes in a supportive environment, phishing quizzes help build their confidence in identifying and responding to phishing attempts effectively."
+    "message": "Employees learn from mistakes in a supportive environment."
   },
   "phishingQuizzes.benefits.tailored.title": {
     "message": "Tailored Learning Objectives:"
   },
   "phishingQuizzes.benefits.tailored.text": {
-    "message": "Quizzes can be customized to focus on specific skills and knowledge gaps, ensuring that employees receive targeted training that effectively equips them to prevent phishing attacks in their daily work."
+    "message": "Quizzes can be customized to focus on specific skills and knowledge gaps."
   },
   "phishingQuizzes.cta": {
     "message": "Get started"

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -200,14 +200,14 @@ export default function About() {
 
                 <li>
                   <Translate id="about.how.design">
-                    At Horizontal, we design and develop centering the needs of the community.
+                    At Horizontal, we design and develop centering the needs of users facing high risks of digital attacks.
                   </Translate>
                 </li>
 
                 <li>
                   <Link to="/contact">
                     <Translate id="about.how.community">
-                      Shira is multilingual, co-created with users and centering security and privacy.
+                      Shira is multilingual and co-created with at-risk users.
                     </Translate>
                   </Link>
                 </li>

--- a/src/pages/contact.js
+++ b/src/pages/contact.js
@@ -43,7 +43,7 @@ export default function Contact() {
 
             <p>
               <Translate id="contact.intro.part1">
-                Do you have questions about Shira (that are not answered in our
+                Do you have questions about Shira that are not answered in our
               </Translate>{' '}
               <Link to="/help">
                 <Translate id="contact.intro.helpCenter">
@@ -51,7 +51,7 @@ export default function Contact() {
                 </Translate>
               </Link>
               <Translate id="contact.intro.part2">
-                )? Would you like to explore a possible partnership? Are you a part of a grassroots organization and cannot afford the full cost of Shira?
+                ? Would you like to explore a possible partnership? Are you a non-profit or a grassroots organization and cannot afford the full cost of Shira?
               </Translate>
             </p>
 
@@ -73,7 +73,7 @@ export default function Contact() {
               <li>
                 <a href="https://github.com/Horizontal-org/shira/discussions">
                   <Translate id="contact.links.github">
-                    Post a feature idea or vote on the community needs
+                    Post a feature idea or vote on existing requests
                   </Translate>
                 </a>.
               </li>

--- a/src/pages/features.js
+++ b/src/pages/features.js
@@ -103,37 +103,37 @@ export default function Features() {
         <section className={classNames(styles.feauturesBox)}>
           <div className={classNames(styles.featureElement, global.backgroundLight)}>
             <h3><Translate id="features.list.ui.title">User-friendly interface 🎨</Translate></h3>
-            <p><Translate id="features.list.ui.description">Intuitive dashboard for easy navigation and management of quizzes and user data.</Translate></p>
+            <p><Translate id="features.list.ui.description">Intuitive dashboard for easy navigation and management of quizzes and users.</Translate></p>
           </div>
 
           <div className={classNames(styles.featureElement, global.backgroundLight)}>
             <h3><Translate id="features.list.roles.title">Role-based access control 🔒</Translate></h3>
-            <p><Translate id="features.list.roles.description">Different access levels for admins, managers, and employees.</Translate></p>
+            <p><Translate id="features.list.roles.description">Different access levels for admins and learners.</Translate></p>
           </div>
 
           <div className={classNames(styles.featureElement, global.backgroundLight)}>
             <h3><Translate id="features.list.realLife.title">Real-Life Attack Simulation ⚡</Translate></h3>
-            <p><Translate id="features.list.realLife.description">Ability to input details from actual phishing attacks the company has experienced.</Translate></p>
+            <p><Translate id="features.list.realLife.description">Include in your quizzes details from actual phishing attacks the company has experienced to best prepare your team.</Translate></p>
           </div>
 
           <div className={classNames(styles.featureElement, global.backgroundLight)}>
             <h3><Translate id="features.list.email.title">Email phishing simulations 📧</Translate></h3>
-            <p><Translate id="features.list.email.description">Create quizzes that mimic phishing emails on Gmail and Outlook, including headers, body, images and attachments.</Translate></p>
+            <p><Translate id="features.list.email.description">Create quizzes that mimic phishing emails on Gmail and Outlook, including sender information, subject line, email body, links, images and file attachments.</Translate></p>
           </div>
 
           <div className={classNames(styles.featureElement, global.backgroundLight)}>
             <h3><Translate id="features.list.sms.title">SMS phishing simulations 💬</Translate></h3>
-            <p><Translate id="features.list.sms.description">Design quizzes that simulate SMS phishing attempts with realistic text messages.</Translate></p>
+            <p><Translate id="features.list.sms.description">Create quizzes that simulate SMS phishing attempts with realistic text messages.</Translate></p>
           </div>
 
           <div className={classNames(styles.featureElement, global.backgroundLight)}>
             <h3><Translate id="features.list.messaging.title">Messaging app phishing simulations 💬</Translate></h3>
-            <p><Translate id="features.list.messaging.description">Include quizzes that replicate phishing through WhatsApp, Messenger, etc.</Translate></p>
+            <p><Translate id="features.list.messaging.description">Create quizzes that replicate phishing through popular messaging apps like WhatsApp or Facebook Messenger.</Translate></p>
           </div>
 
           <div className={classNames(styles.featureElement, global.backgroundLight)}>
             <h3><Translate id="features.list.mobile.title">Mobile support 📱</Translate></h3>
-            <p><Translate id="features.list.mobile.description">Users can take Shira quizzes on mobile devices to simulate real-life scenarios.</Translate></p>
+            <p><Translate id="features.list.mobile.description">We often face phishing attacks from our mobile devices. In Shira, users can take quizzes from their mobile devices to prepare for attacks they will face in real life.</Translate></p>
           </div>
 
           <div className={classNames(styles.featureElement, global.backgroundLight)}>
@@ -143,17 +143,17 @@ export default function Features() {
 
           <div className={classNames(styles.featureElement, global.backgroundLight)}>
             <h3><Translate id="features.list.analytics.title">Analytics 📈</Translate></h3>
-            <p><Translate id="features.list.analytics.description">Track user progress and identify areas for improvement.</Translate></p>
+            <p><Translate id="features.list.analytics.description">Track user progress and identify areas for improvement, whether it's the type of apps your users are most vulnerable on or the specific users who need extra support.</Translate></p>
           </div>
 
           <div className={classNames(styles.featureElement, global.backgroundLight)}>
             <h3><Translate id="features.list.explanations.title">Explanations 📝</Translate></h3>
-            <p><Translate id="features.list.explanations.description">Embed your own explanations on why an email or message looks like phishing.</Translate></p>
+            <p><Translate id="features.list.explanations.description">Embed your own explanations to point users to elements that suggest that an email or message looks like phishing.</Translate></p>
           </div>
 
           <div className={classNames(styles.featureElement, global.backgroundLight)}>
             <h3><Translate id="features.list.gamification.title">Gamification 🕹️</Translate></h3>
-            <p><Translate id="features.list.gamification.description">An entertaining learning experience promotes better knowledge retention.</Translate></p>
+            <p><Translate id="features.list.gamification.description">An engaging learning experience promotes better knowledge retention.</Translate></p>
           </div>
 
           <div className={classNames(styles.featureElement, global.backgroundLight)}>
@@ -163,7 +163,7 @@ export default function Features() {
 
           <div className={classNames(styles.featureElement, global.backgroundLight)}>
             <h3><Translate id="features.list.library.title">Question library 📚</Translate></h3>
-            <p><Translate id="features.list.library.description">Pull from Shira's question library to start your trainings from templates created by digital security trainers.</Translate></p>
+            <p><Translate id="features.list.library.description">Create your quiz questions from scratch or head to the Shira Library to pull question templates created by digital security trainers.</Translate></p>
           </div>
         </section>
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -24,7 +24,7 @@ export default function Home() {
       })}
       description={translate({
         id: 'homepage.meta.description',
-        message: "Shira builds your team's ability to identify and defeat phishing attacks.",
+        message: "Use Shira to build your team's ability to identify and defeat phishing attacks.",
       })}
     >
       <meta
@@ -61,7 +61,7 @@ export default function Home() {
                 <Translate id="homepage.learners.description">
                   Get started right away with one of our free, ready-made quizzes.
                   Customize the quiz to learn to identify phishing in the apps you use
-                  in real life — Gmail, SMS, WhatsApp, etc — with examples tailored to
+                  every day — Gmail, SMS, WhatsApp, etc — with examples tailored to
                   your language and field of work.
                 </Translate>
               </p>
@@ -82,7 +82,7 @@ export default function Home() {
                 <Translate id="homepage.educators.description">
                   Each organization has its own needs and faces its own threats.
                   Build phishing quizzes tailored to your organization’s needs and
-                  monitor your team’s success rates — all without technical skills.
+                  monitor your team’s success rates — without any coding.
                 </Translate>
               </p>
               <Link className={global.buttonLight} to={getSignupUrl()}>
@@ -95,8 +95,8 @@ export default function Home() {
         <section className={classNames(global.row, global.center, styles.context)}>
           <p>
             <Translate id="homepage.context.description">
-              For years, phishing has been one of the most common types of attacks
-              facing individuals and organizations. While it has been traditionally
+              For years, phishing has been one of the most common attacks
+              facing individuals and organizations. While it was initially
               limited to emails, phishing now also happens via SMS, messaging apps,
               and social media. Building users’ skills to identify and defeat phishing
               attacks is more needed than ever before.
@@ -134,7 +134,7 @@ export default function Home() {
               <p>
                 <Translate id="homepage.why.intro">
                   Whether you’re just taking our ready-made, free quizzes, or you’re
-                  taking the time to build your own custom quizzes, Shira is:
+                  building your own custom quizzes to train your team, Shira is:
                 </Translate>
               </p>
 
@@ -169,7 +169,7 @@ export default function Home() {
                   </span>
                   <p>
                     <Translate id="homepage.why.privacy.description">
-                      We do not collect or share any user data.
+                      We do not collect or share any sensitive or personally-identifiable user data.
                     </Translate>
                   </p>
                 </li>

--- a/src/pages/phishing-quizzes.js
+++ b/src/pages/phishing-quizzes.js
@@ -18,12 +18,11 @@ export default function PhishingQuizzes() {
     <Layout
       title={translate({
         id: 'phishingQuizzes.meta.title',
-        message: 'Learn about Phishing quizzes',
+        message: 'Learn about Phishing Quizzes',
       })}
       description={translate({
         id: 'phishingQuizzes.meta.description',
-        message:
-          'Learn why phishing quizzes are more effective than simulations. Shira offers safe, interactive training to build real phishing detection skills without stress or punishment.',
+        message: 'Learn about Phishing quizzes',
       })}
     >
       <main className={classNames(global.main, styles.phishingQuizzes)}>
@@ -31,8 +30,7 @@ export default function PhishingQuizzes() {
           name="description"
           content={translate({
             id: 'phishingQuizzes.meta.description',
-            message:
-              'Learn why phishing quizzes are more effective than simulations. Shira offers safe, interactive training to build real phishing detection skills without stress or punishment.',
+            message: 'Learn about Phishing quizzes',
           })}
         />
 
@@ -80,7 +78,7 @@ export default function PhishingQuizzes() {
                 alt={translate({
                   id: 'phishingQuizzes.wsj.alt',
                   message:
-                    'news article from the wall street journal Phishing Tests, the Bane of Work Life, Are Getting Meaner - Researchers say the ruses, aimed at teaching gullible employees about the dangers lurking online, don’t even work',
+                    "news article from the Wall Street Journal: 'Phishing Tests, the Bane of Work Life, Are Getting Meaner'- Researchers say the ruses, aimed at teaching gullible employees about the dangers lurking online, don’t even work",
                 })}
               />
 
@@ -90,7 +88,7 @@ export default function PhishingQuizzes() {
                 alt={translate({
                   id: 'phishingQuizzes.wsjMobile.alt',
                   message:
-                    'news article from the wall street journal Phishing Tests, the Bane of Work Life, Are Getting Meaner - Researchers say the ruses, aimed at teaching gullible employees about the dangers lurking online, don’t even work',
+                    "news article from the Wall Street Journal: 'Phishing Tests, the Bane of Work Life, Are Getting Meaner'- Researchers say the ruses, aimed at teaching gullible employees about the dangers lurking online, don’t even work",
                 })}
               />
             </a>
@@ -136,7 +134,7 @@ export default function PhishingQuizzes() {
                   </Translate>
                 </span>{' '}
                 <Translate id="phishingQuizzes.problem.emailFocus.text">
-                  Many phishing simulations primarily target email threats, overlooking other channels like SMS, messaging apps, or social media. This limited focus can leave employees unprepared to recognize and respond to phishing attempts outside their email inbox.
+                  Many phishing simulations primarily target email threats, overlooking other channels like SMS, messaging apps, or social media.
                 </Translate>
               </li>
 
@@ -147,7 +145,7 @@ export default function PhishingQuizzes() {
                   </Translate>
                 </span>{' '}
                 <Translate id="phishingQuizzes.problem.falseSecurity.text">
-                  If employees successfully identify simulated phishing attempts, they may develop a false sense of security, believing they are fully equipped to handle real threats, which can lead to complacency.
+                  If employees successfully identify simulated phishing attempts, they may develop a false sense of security.
                 </Translate>
               </li>
 
@@ -158,7 +156,7 @@ export default function PhishingQuizzes() {
                   </Translate>
                 </span>{' '}
                 <Translate id="phishingQuizzes.problem.clickRates.text">
-                  Focusing solely on whether employees clicked on a link can overlook other important aspects of phishing awareness, such as recognizing social engineering tactics or reporting suspicious emails.
+                  Focusing solely on whether employees clicked on a link can overlook other important aspects of phishing awareness.
                 </Translate>
               </li>
 
@@ -169,7 +167,7 @@ export default function PhishingQuizzes() {
                   </Translate>
                 </span>{' '}
                 <Translate id="phishingQuizzes.problem.desensitize.text">
-                  Repeatedly sending fake phishing emails can desensitize users to the threat, making them less likely to take real phishing attempts seriously.
+                  Repeatedly sending fake phishing emails can desensitize users to the threat.
                 </Translate>
               </li>
 
@@ -180,7 +178,7 @@ export default function PhishingQuizzes() {
                   </Translate>
                 </span>{' '}
                 <Translate id="phishingQuizzes.problem.punishment.text">
-                  Simulated phishing emails can create a culture of fear, where users are more focused on avoiding punishment than on learning how to prevent phishing attacks.
+                  Simulated phishing emails can create a culture of fear, where users are more focused on avoiding punishment than on learning.
                 </Translate>
               </li>
             </ol>
@@ -204,7 +202,7 @@ export default function PhishingQuizzes() {
               </Translate>
             </i>{' '}
             <Translate id="phishingQuizzes.research.final">
-              effect of phishing simulations: users who are continuously exposed to phishing simulations are more likely to click on dangerous links.
+              effect of phishing simulations.
             </Translate>
           </p>
 
@@ -216,7 +214,7 @@ export default function PhishingQuizzes() {
 
           <p>
             <Translate id="phishingQuizzes.quizzes.description">
-              Phishing quizzes provide a controlled learning environment that is more effective for skill-building than traditional phishing simulations. Unlike simulations, which can be stressful and punitive, quizzes offer a safe and interactive space for employees to practice their phishing detection skills. Designed to mimic real-world scenarios without actual risk, these quizzes encourage active learning and allow participants to receive immediate feedback. This helps employees learn from their mistakes, build confidence, and understand why certain emails are phishing attempts.
+              Phishing quizzes provide a controlled learning environment that is more effective for skill-building than traditional phishing simulations.
             </Translate>
           </p>
 
@@ -235,7 +233,7 @@ export default function PhishingQuizzes() {
                   </Translate>
                 </span>{' '}
                 <Translate id="phishingQuizzes.benefits.controlled.text">
-                  Phishing quizzes create a safe and low-stakes space for employees to practice their skills, reducing the stress and anxiety often associated with traditional phishing simulations.
+                  Phishing quizzes create a safe and low-stakes space for employees to practice their skills.
                 </Translate>
               </li>
 
@@ -246,7 +244,7 @@ export default function PhishingQuizzes() {
                   </Translate>
                 </span>{' '}
                 <Translate id="phishingQuizzes.benefits.interactive.text">
-                  These quizzes encourage active participation by allowing employees to engage with various phishing scenarios, while also providing immediate feedback on what elements indicate that an email or message may be a phishing attack.
+                  These quizzes encourage active participation and provide immediate feedback.
                 </Translate>
               </li>
 
@@ -257,7 +255,7 @@ export default function PhishingQuizzes() {
                   </Translate>
                 </span>{' '}
                 <Translate id="phishingQuizzes.benefits.coverage.text">
-                  Phishing quizzes can incorporate questions about various types of phishing attacks, such as SMS (smishing), social media, and voice calls (vishing), broadening employees' awareness and preparedness for threats beyond just email.
+                  Phishing quizzes can incorporate SMS, social media, and voice phishing scenarios.
                 </Translate>
               </li>
 
@@ -268,7 +266,7 @@ export default function PhishingQuizzes() {
                   </Translate>
                 </span>{' '}
                 <Translate id="phishingQuizzes.benefits.confidence.text">
-                  By allowing employees to learn from their mistakes in a supportive environment, phishing quizzes help build their confidence in identifying and responding to phishing attempts effectively.
+                  Employees learn from mistakes in a supportive environment.
                 </Translate>
               </li>
 
@@ -279,7 +277,7 @@ export default function PhishingQuizzes() {
                   </Translate>
                 </span>{' '}
                 <Translate id="phishingQuizzes.benefits.tailored.text">
-                  Quizzes can be customized to focus on specific skills and knowledge gaps, ensuring that employees receive targeted training that effectively equips them to prevent phishing attacks in their daily work.
+                  Quizzes can be customized to focus on specific skills and knowledge gaps.
                 </Translate>
               </li>
             </ol>


### PR DESCRIPTION
Follow-up to #31.

The commit `22d60ea` ("restored correct english source from code") was
misleading: it actually regenerated `i18n/en/code.json` from `src/pages`
and overwrote the curated English copy that existed before `0589d43`.

This commit realigns both `src/pages/*.js` and `i18n/en/code.json` with
that pre-`0589d43` reference.

**Scope**
- `src/pages/about.js` (2 strings)
- `src/pages/contact.js` (3)
- `src/pages/features.js` (11)
- `src/pages/index.js` (6)
- `src/pages/phishing-quizzes.js` (16)
- `i18n/en/code.json` (38 in mirror)

**Out of scope**
- The pricing page (refactored to use `@horizontal/pricing` library — no
  pre-`0589d43` equivalent to restore).
- Other locales (fr/es/ar/ru/zh).

Review by Raph.